### PR TITLE
Add resource counts to the filter api

### DIFF
--- a/com/coralogix/xdr/v1/filter/filter_service.proto
+++ b/com/coralogix/xdr/v1/filter/filter_service.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package com.coralogix.xdr.v1.filter;
+
+import "com/coralogix/xdr/v1/audit_log.proto";
+import "com/coralogix/xdr/v1/filter/security_test_filter.proto";
+
+import "google/api/annotations.proto";
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+service SecurityTestService {
+
+  rpc GetFilterableFields(GetFilterableFieldsRequest) returns (GetFilterableFieldsResponse){
+    option (audit_log_description).description = "get list of fields to use in filtering";
+    option (google.api.http) = {
+      post: "/xdr/v1/filter/filterable-fields"
+    };
+  }
+
+  rpc GetFilterAggs(GetFilterAggsRequest) returns (GetFilterAggsResponse) {
+    option (audit_log_description).description = "get filter aggregations - value counts";
+    option (google.api.http) = {
+      post: "/xdr/v1/filter/{execution_id}/filter-aggregations"
+      body: "*"
+    };
+  }
+}
+
+message GetFilterAggsRequest {
+  google.protobuf.StringValue execution_id = 1; // UUID
+  com.coralogix.xdr.v1.filter.SecurityTestFilter filter = 2;
+}
+
+message GetFilterAggsResponse {
+  google.protobuf.StringValue execution_id = 1; // UUID
+  com.coralogix.xdr.v1.filter.FilterCounts test_counts = 2;
+  com.coralogix.xdr.v1.filter.FilterCounts resource_counts = 3;
+}
+
+message GetFilterableFieldsRequest {
+}
+
+message GetFilterableFieldsResponse {
+
+  message DynamicAttributes {
+    repeated com.coralogix.xdr.v1.rule.DynamicAttribute dynamic_attributes = 1;
+  }
+
+  map<string, DynamicAttributes> provider_filters = 1;
+  map<string, DynamicAttributes> service_filters = 2;
+  map<string, DynamicAttributes> security_rule_filters = 3;
+}

--- a/com/coralogix/xdr/v1/filter/filter_service.proto
+++ b/com/coralogix/xdr/v1/filter/filter_service.proto
@@ -3,14 +3,14 @@ syntax = "proto3";
 package com.coralogix.xdr.v1.filter;
 
 import "com/coralogix/xdr/v1/audit_log.proto";
+import "com/coralogix/xdr/v1/rule/security_rule.proto";
 import "com/coralogix/xdr/v1/filter/security_test_filter.proto";
 
 import "google/api/annotations.proto";
 import "google/protobuf/descriptor.proto";
-import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
-service SecurityTestService {
+service FilterService {
 
   rpc GetFilterableFields(GetFilterableFieldsRequest) returns (GetFilterableFieldsResponse){
     option (audit_log_description).description = "get list of fields to use in filtering";

--- a/com/coralogix/xdr/v1/filter/filter_service.proto
+++ b/com/coralogix/xdr/v1/filter/filter_service.proto
@@ -19,10 +19,18 @@ service FilterService {
     };
   }
 
-  rpc GetFilterAggs(GetFilterAggsRequest) returns (GetFilterAggsResponse) {
-    option (audit_log_description).description = "get filter aggregations - value counts";
+  rpc GetTestFilterAggs(GetFilterAggsRequest) returns (GetFilterAggsResponse) {
+    option (audit_log_description).description = "get filter aggregations - test value counts";
     option (google.api.http) = {
-      post: "/xdr/v1/filter/{execution_id}/filter-aggregations"
+      post: "/xdr/v1/filter/{execution_id}/test-filter-aggregations"
+      body: "*"
+    };
+  }
+
+  rpc GetResourceFilterAggs(GetFilterAggsRequest) returns (GetFilterAggsResponse) {
+    option (audit_log_description).description = "get filter aggregations - resource value counts";
+    option (google.api.http) = {
+      post: "/xdr/v1/filter/{execution_id}/resource-filter-aggregations"
       body: "*"
     };
   }
@@ -35,8 +43,7 @@ message GetFilterAggsRequest {
 
 message GetFilterAggsResponse {
   google.protobuf.StringValue execution_id = 1; // UUID
-  com.coralogix.xdr.v1.filter.FilterCounts test_counts = 2;
-  com.coralogix.xdr.v1.filter.FilterCounts resource_counts = 3;
+  com.coralogix.xdr.v1.filter.FilterCounts filter_counts = 2;
 }
 
 message GetFilterableFieldsRequest {

--- a/com/coralogix/xdr/v1/filter/filter_service.proto
+++ b/com/coralogix/xdr/v1/filter/filter_service.proto
@@ -22,7 +22,7 @@ service FilterService {
   rpc GetTestFilterAggs(GetTestFilterAggsRequest) returns (GetTestFilterAggsResponse) {
     option (audit_log_description).description = "get filter aggregations - test value counts";
     option (google.api.http) = {
-      post: "/xdr/v1/filter/{execution_id}/test-filter-aggregations"
+      post: "/xdr/v1/filter/test-filter-aggregations"
       body: "*"
     };
   }
@@ -30,7 +30,7 @@ service FilterService {
   rpc GetResourceFilterAggs(GetResourceFilterAggsRequest) returns (GetResourceFilterAggsResponse) {
     option (audit_log_description).description = "get filter aggregations - resource value counts";
     option (google.api.http) = {
-      post: "/xdr/v1/filter/{execution_id}/resource-filter-aggregations"
+      post: "/xdr/v1/filter/resource-filter-aggregations"
       body: "*"
     };
   }

--- a/com/coralogix/xdr/v1/filter/filter_service.proto
+++ b/com/coralogix/xdr/v1/filter/filter_service.proto
@@ -19,7 +19,7 @@ service FilterService {
     };
   }
 
-  rpc GetTestFilterAggs(GetFilterAggsRequest) returns (GetFilterAggsResponse) {
+  rpc GetTestFilterAggs(GetTestFilterAggsRequest) returns (GetTestFilterAggsResponse) {
     option (audit_log_description).description = "get filter aggregations - test value counts";
     option (google.api.http) = {
       post: "/xdr/v1/filter/{execution_id}/test-filter-aggregations"
@@ -27,7 +27,7 @@ service FilterService {
     };
   }
 
-  rpc GetResourceFilterAggs(GetFilterAggsRequest) returns (GetFilterAggsResponse) {
+  rpc GetResourceFilterAggs(GetResourceFilterAggsRequest) returns (GetResourceFilterAggsResponse) {
     option (audit_log_description).description = "get filter aggregations - resource value counts";
     option (google.api.http) = {
       post: "/xdr/v1/filter/{execution_id}/resource-filter-aggregations"
@@ -36,15 +36,26 @@ service FilterService {
   }
 }
 
-message GetFilterAggsRequest {
+message GetTestFilterAggsRequest {
   google.protobuf.StringValue execution_id = 1; // UUID
   com.coralogix.xdr.v1.filter.SecurityTestFilter filter = 2;
 }
 
-message GetFilterAggsResponse {
+message GetTestFilterAggsResponse {
   google.protobuf.StringValue execution_id = 1; // UUID
   com.coralogix.xdr.v1.filter.FilterCounts filter_counts = 2;
 }
+
+message GetResourceFilterAggsRequest {
+  google.protobuf.StringValue execution_id = 1; // UUID
+  com.coralogix.xdr.v1.filter.SecurityTestFilter filter = 2;
+}
+
+message GetResourceFilterAggsResponse {
+  google.protobuf.StringValue execution_id = 1; // UUID
+  com.coralogix.xdr.v1.filter.FilterCounts filter_counts = 2;
+}
+
 
 message GetFilterableFieldsRequest {
 }

--- a/com/coralogix/xdr/v1/filter/security_test_filter.proto
+++ b/com/coralogix/xdr/v1/filter/security_test_filter.proto
@@ -42,6 +42,11 @@ message CustomFilterValueCounts {
   map<string, google.protobuf.UInt32Value> filter_values = 1;
 }
 
+message FilterCounts {
+  LogFilterCounts log_filter = 1;
+  SecurityRuleFilterCounts security_rule_filter = 2;
+}
+
 message LogFilterCounts {
   map<string, google.protobuf.UInt32Value> test_identity = 1;
   map<string, google.protobuf.UInt32Value> item = 2;

--- a/com/coralogix/xdr/v1/provider/provider_service.proto
+++ b/com/coralogix/xdr/v1/provider/provider_service.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package com.coralogix.xdr.v1.provider;
 
-import "com/coralogix/xdr/v1/rule/security_rule.proto";
 import "com/coralogix/xdr/v1/filter/security_test_filter.proto";
 import "com/coralogix/xdr/v1/provider/provider.proto";
 import "com/coralogix/xdr/v1/audit_log.proto";
@@ -40,12 +39,16 @@ message GetProviderSummaryRequest {
 }
 
 message GetProviderSummaryResponse {
-  message ProviderWithSummary {
-    Provider provider = 1;
-    google.protobuf.UInt64Value failed_count = 2;
-    google.protobuf.UInt64Value passed_count = 3;
-    google.protobuf.UInt64Value total_count = 4;
+  message Summary {
+    google.protobuf.UInt64Value failed_count = 1;
+    google.protobuf.UInt64Value passed_count = 2;
+    google.protobuf.UInt64Value total_count = 3;
   }
-  repeated ProviderWithSummary summaries = 1;
+  message ProviderWithSummaries {
+    Provider provider = 1;
+    Summary test_summaries = 2;
+    Summary resource_summaries = 3;
+  }
+  repeated ProviderWithSummaries provider_summaries = 1;
   google.protobuf.StringValue execution_id = 2;
 }

--- a/com/coralogix/xdr/v1/provider/provider_service.proto
+++ b/com/coralogix/xdr/v1/provider/provider_service.proto
@@ -47,7 +47,7 @@ message GetProviderTestSummaryRequest {
 }
 
 message GetProviderTestSummaryResponse {
-  repeated ProviderWithSummaries provider_summaries = 1;
+  repeated ProviderWithSummary provider_summary = 1;
   google.protobuf.StringValue execution_id = 2;
 }
 
@@ -57,12 +57,12 @@ message GetProviderResourceSummaryRequest {
 }
 
 message GetProviderResourceSummaryResponse {
-  repeated ProviderWithSummaries provider_summaries = 1;
+  repeated ProviderWithSummary provider_summary = 1;
   google.protobuf.StringValue execution_id = 2;
 }
 
 
-message ProviderWithSummaries {
+message ProviderWithSummary {
   Provider provider = 1;
   google.protobuf.UInt64Value failed_count = 2;
   google.protobuf.UInt64Value passed_count = 3;

--- a/com/coralogix/xdr/v1/provider/provider_service.proto
+++ b/com/coralogix/xdr/v1/provider/provider_service.proto
@@ -11,10 +11,18 @@ import "google/protobuf/descriptor.proto";
 import "google/api/annotations.proto";
 
 service ProviderService {
-  rpc GetProviderSummary (GetProviderSummaryRequest) returns (GetProviderSummaryResponse) {
+  rpc GetProviderTestSummary (GetProviderTestSummaryRequest) returns (GetProviderTestSummaryResponse) {
     option (audit_log_description).description = "get platform summary";
     option (google.api.http) = {
-      post: "/xdr/v1/get_provider_summaries"
+      post: "/xdr/v1/get_provider_test_summaries"
+      body: "*"
+    };
+  }
+
+  rpc GetProviderResourceSummary (GetProviderResourceSummaryRequest) returns (GetProviderResourceSummaryResponse) {
+    option (audit_log_description).description = "get platform summary";
+    option (google.api.http) = {
+      post: "/xdr/v1/get_provider_resource_summaries"
       body: "*"
     };
   }
@@ -33,22 +41,30 @@ message GetProvidersResponse {
   repeated Provider data = 1;
 }
 
-message GetProviderSummaryRequest {
+message GetProviderTestSummaryRequest {
   optional google.protobuf.StringValue execution_id = 1;
   optional com.coralogix.xdr.v1.filter.SecurityTestFilter filter = 2;
 }
 
-message GetProviderSummaryResponse {
-  message Summary {
-    google.protobuf.UInt64Value failed_count = 1;
-    google.protobuf.UInt64Value passed_count = 2;
-    google.protobuf.UInt64Value total_count = 3;
-  }
-  message ProviderWithSummaries {
-    Provider provider = 1;
-    Summary test_summaries = 2;
-    Summary resource_summaries = 3;
-  }
+message GetProviderTestSummaryResponse {
   repeated ProviderWithSummaries provider_summaries = 1;
   google.protobuf.StringValue execution_id = 2;
+}
+
+message GetProviderResourceSummaryRequest {
+  optional google.protobuf.StringValue execution_id = 1;
+  optional com.coralogix.xdr.v1.filter.SecurityTestFilter filter = 2;
+}
+
+message GetProviderResourceSummaryResponse {
+  repeated ProviderWithSummaries provider_summaries = 1;
+  google.protobuf.StringValue execution_id = 2;
+}
+
+
+message ProviderWithSummaries {
+  Provider provider = 1;
+  google.protobuf.UInt64Value failed_count = 2;
+  google.protobuf.UInt64Value passed_count = 3;
+  google.protobuf.UInt64Value total_count = 4;
 }

--- a/com/coralogix/xdr/v1/provider/provider_service.proto
+++ b/com/coralogix/xdr/v1/provider/provider_service.proto
@@ -47,7 +47,7 @@ message GetProviderTestSummaryRequest {
 }
 
 message GetProviderTestSummaryResponse {
-  repeated ProviderWithSummary provider_summary = 1;
+  repeated ProviderWithSummary provider_summaries = 1;
   google.protobuf.StringValue execution_id = 2;
 }
 
@@ -57,7 +57,7 @@ message GetProviderResourceSummaryRequest {
 }
 
 message GetProviderResourceSummaryResponse {
-  repeated ProviderWithSummary provider_summary = 1;
+  repeated ProviderWithSummary provider_summaries = 1;
   google.protobuf.StringValue execution_id = 2;
 }
 

--- a/com/coralogix/xdr/v1/test/security_test_service.proto
+++ b/com/coralogix/xdr/v1/test/security_test_service.proto
@@ -139,15 +139,15 @@ message GetTestSubjectResponse {
   TestSubjectDetails subject_details = 1;
 }
 
+// Deprecated - TODO remove filter related fields in followup
 message GetSecurityTestFilterAggsRequest {
   google.protobuf.StringValue execution_id = 1; // UUID
   com.coralogix.xdr.v1.filter.SecurityTestFilter filter = 2;
 }
 
 message GetSecurityTestFilterAggsResponse {
-  google.protobuf.StringValue execution_id = 1; // UUID
-  com.coralogix.xdr.v1.filter.FilterCounts test_counts = 2;
-  com.coralogix.xdr.v1.filter.FilterCounts resource_counts = 3;
+  com.coralogix.xdr.v1.filter.LogFilterCounts log_filter = 1;
+  com.coralogix.xdr.v1.filter.SecurityRuleFilterCounts security_rule_filter = 2;
 }
 
 message GetFilterableFieldsRequest {

--- a/com/coralogix/xdr/v1/test/security_test_service.proto
+++ b/com/coralogix/xdr/v1/test/security_test_service.proto
@@ -145,8 +145,9 @@ message GetSecurityTestFilterAggsRequest {
 }
 
 message GetSecurityTestFilterAggsResponse {
-  com.coralogix.xdr.v1.filter.LogFilterCounts log_filter = 1;
-  com.coralogix.xdr.v1.filter.SecurityRuleFilterCounts security_rule_filter = 2;
+  google.protobuf.StringValue execution_id = 1; // UUID
+  com.coralogix.xdr.v1.filter.FilterCounts test_counts = 2;
+  com.coralogix.xdr.v1.filter.FilterCounts resource_counts = 3;
 }
 
 message GetFilterableFieldsRequest {

--- a/com/coralogix/xdr/v1/test/security_test_service.proto
+++ b/com/coralogix/xdr/v1/test/security_test_service.proto
@@ -13,7 +13,6 @@ import "com/coralogix/xdr/v1/filter/security_test_filter.proto";
 
 import "google/api/annotations.proto";
 import "google/protobuf/descriptor.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 


### PR DESCRIPTION
Add another rpc call for resource counts filter. The reason is that for security rule based filters, we need to do composite aggregation which may have worse performance and we would like to avoid negative impact on the other screens which don't really need it.
This PR also introduce another endpoint for provider resource summaries which is also using composite aggregation as there's not better solution for now. It's also extracted to another endpoint for performance reasons.
The third thing added is resource count to the inventory endpoint. This is just doing another call to the elastic search to get unique resource counts using cardinality aggregation.

To not break backward compatibility, new service specifically for filter functionality was created. It'll simplify the implementation and separate filter related logic and tests to another place where it wouldn't be mixed up with other functionality.
We will remove the existing one as soon as we migrate backend and frontend on all environments.
Feel free to discuss if you have a better idea :) 

[sc-7806]