### PR TITLE
Add "is_active" field on SecurityTestItem and "is_active" field on ResourceResults

### DIFF
--- a/com/coralogix/xdr/v1/test/security_test_breakdown.proto
+++ b/com/coralogix/xdr/v1/test/security_test_breakdown.proto
@@ -25,6 +25,7 @@ message SecurityTestItem {
   com.coralogix.xdr.v1.rule.SecurityRule rule = 1;
   google.protobuf.UInt32Value passed_count = 2;
   google.protobuf.UInt32Value failed_count = 3;
+  google.protobuf.BoolValue is_rule_active = 4;
 }
 
 message SecurityTestBreakdown {

--- a/com/coralogix/xdr/v1/test/security_test_breakdown.proto
+++ b/com/coralogix/xdr/v1/test/security_test_breakdown.proto
@@ -25,7 +25,7 @@ message SecurityTestItem {
   com.coralogix.xdr.v1.rule.SecurityRule rule = 1;
   google.protobuf.UInt32Value passed_count = 2;
   google.protobuf.UInt32Value failed_count = 3;
-  google.protobuf.BoolValue is_rule_active = 4;
+  google.protobuf.BoolValue is_active = 4;
 }
 
 message SecurityTestBreakdown {

--- a/com/coralogix/xdr/v1/test/security_test_service.proto
+++ b/com/coralogix/xdr/v1/test/security_test_service.proto
@@ -151,6 +151,7 @@ message GetResourceResultsByRuleCategoryResponse {
     google.protobuf.StringValue service_name = 2;
     google.protobuf.UInt32Value passed_count = 3;
     google.protobuf.UInt32Value failed_count = 4;
+    google.protobuf.BoolValue is_resource_active = 5;
   }
 
   message RuleCategoryGroup {

--- a/com/coralogix/xdr/v1/test/security_test_service.proto
+++ b/com/coralogix/xdr/v1/test/security_test_service.proto
@@ -151,7 +151,7 @@ message GetResourceResultsByRuleCategoryResponse {
     google.protobuf.StringValue service_name = 2;
     google.protobuf.UInt32Value passed_count = 3;
     google.protobuf.UInt32Value failed_count = 4;
-    google.protobuf.BoolValue is_resource_active = 5;
+    google.protobuf.BoolValue is_active = 5;
   }
 
   message RuleCategoryGroup {


### PR DESCRIPTION
[sc-9298]

Adding the `is_active` field on `SecurityTestItem` instead of on the `SecurityRule` seems cleaner, because the `SecurityRule` is also used on crudish endpoints in which it doesn't make sense to have it.
We are interested in this field only on the read part of the application, as it is supplied at ingestion, not on any `SecurityRule` crud endpoint.