### PR TITLE
Add `not_applicable` and `inactive` counts + deprecate fields on breakdown response

### DIFF
--- a/com/coralogix/xdr/v1/test/security_test_breakdown.proto
+++ b/com/coralogix/xdr/v1/test/security_test_breakdown.proto
@@ -20,7 +20,7 @@ message CountByResult {
   google.protobuf.UInt32Value failed = 2;
   optional SeveritiesCount failed_severities = 3;
   google.protobuf.UInt32Value inactive = 4;
-  google.protobuf.UInt32Value unrelated = 5;
+  google.protobuf.UInt32Value not_applicable = 5;
 }
 
 message SecurityTestItem {

--- a/com/coralogix/xdr/v1/test/security_test_breakdown.proto
+++ b/com/coralogix/xdr/v1/test/security_test_breakdown.proto
@@ -19,6 +19,8 @@ message CountByResult {
   google.protobuf.UInt32Value passed = 1;
   google.protobuf.UInt32Value failed = 2;
   optional SeveritiesCount failed_severities = 3;
+  google.protobuf.UInt32Value inactive = 4;
+  google.protobuf.UInt32Value unrelated = 5;
 }
 
 message SecurityTestItem {
@@ -29,11 +31,9 @@ message SecurityTestItem {
 }
 
 message SecurityTestBreakdown {
-  reserved 5;
-  reserved "count_by_severity";
+  reserved 5, 2, 4;
+  reserved "count_by_severity", "security_test_items", "all_count";
   google.protobuf.StringValue execution_id = 1; // UUID
-  repeated SecurityTestItem security_test_items = 2;
   google.protobuf.Timestamp executed_at = 3;
-  google.protobuf.UInt32Value all_count = 4;
   CountByResult security_rule_result = 6;
 }


### PR DESCRIPTION
[sc-9935]
[sc-10269]