### PR TITLE
Extend scan functionality

### DIFF
--- a/com/coralogix/xdr/v1/scheduling/schedule_service.proto
+++ b/com/coralogix/xdr/v1/scheduling/schedule_service.proto
@@ -25,22 +25,6 @@ service SchedulingService {
       get: "/xdr/scheduling/v1/schedule"
     };
   }
-
-  rpc RegisterScan(RegisterScanRequest) returns (RegisterScanResponse) {
-    option (audit_log_description).description = "register a new scan";
-    option (google.api.http) = {
-      post: "/xdr/scheduling/v1/schedule/register/scan"
-      body: "*"
-    };
-  }
-}
-
-message RegisterScanRequest {
-  google.protobuf.StringValue provider = 1;
-}
-
-message RegisterScanResponse {
-  bool registered = 1;
 }
 
 message GetScheduleResponse {
@@ -55,8 +39,6 @@ message CreateOrUpdateScheduleResponse {}
 message CreateOrUpdateScheduleRequest {
   Schedule schedule = 1;
 }
-
-message UpdateScheduleResponse {}
 
 message Schedule {
   TimeOfDay time_of_day = 1; // 12 hours 00 minutes

--- a/com/coralogix/xdr/v1/scheduling/schedule_service.proto
+++ b/com/coralogix/xdr/v1/scheduling/schedule_service.proto
@@ -27,7 +27,7 @@ service SchedulingService {
   }
 
   rpc ScanNow(ScanNowRequest) returns (ScanNowResponse) {
-    option (audit_log_description).description = "insert a manual scan";
+    option (audit_log_description).description = "schedule a manual scan";
     option (google.api.http) = {
       get: "/xdr/scheduling/v1/schedule/scan/now"
     };

--- a/com/coralogix/xdr/v1/scheduling/schedule_service.proto
+++ b/com/coralogix/xdr/v1/scheduling/schedule_service.proto
@@ -25,6 +25,18 @@ service SchedulingService {
       get: "/xdr/scheduling/v1/schedule"
     };
   }
+
+  rpc RunNow(ScanNowRequest) returns (ScanNowResponse) {
+    option (audit_log_description).description = "insert a manual scan";
+    option (google.api.http) = {
+      get: "/xdr/scheduling/v1/schedule/scan/now"
+    };
+  }
+}
+
+message ScanNowRequest{}
+message ScanNowResponse{
+  google.protobuf.BoolValue canRun = 1;
 }
 
 message GetScheduleResponse {

--- a/com/coralogix/xdr/v1/scheduling/schedule_service.proto
+++ b/com/coralogix/xdr/v1/scheduling/schedule_service.proto
@@ -36,7 +36,7 @@ service SchedulingService {
 
 message ScanNowRequest{}
 message ScanNowResponse{
-  google.protobuf.BoolValue canRun = 1;
+  google.protobuf.BoolValue can_run = 1;
 }
 
 message GetScheduleResponse {

--- a/com/coralogix/xdr/v1/scheduling/schedule_service.proto
+++ b/com/coralogix/xdr/v1/scheduling/schedule_service.proto
@@ -36,7 +36,7 @@ service SchedulingService {
 
 message ScanNowRequest{}
 message ScanNowResponse{
-  google.protobuf.BoolValue can_run = 1;
+  google.protobuf.BoolValue registered = 1;
 }
 
 message GetScheduleResponse {

--- a/com/coralogix/xdr/v1/scheduling/schedule_service.proto
+++ b/com/coralogix/xdr/v1/scheduling/schedule_service.proto
@@ -26,7 +26,7 @@ service SchedulingService {
     };
   }
 
-  rpc RunNow(ScanNowRequest) returns (ScanNowResponse) {
+  rpc ScanNow(ScanNowRequest) returns (ScanNowResponse) {
     option (audit_log_description).description = "insert a manual scan";
     option (google.api.http) = {
       get: "/xdr/scheduling/v1/schedule/scan/now"

--- a/com/coralogix/xdr/v1/scheduling/schedule_service.proto
+++ b/com/coralogix/xdr/v1/scheduling/schedule_service.proto
@@ -32,6 +32,18 @@ service SchedulingService {
       get: "/xdr/scheduling/v1/schedule/scan/now"
     };
   }
+
+  rpc GetManualExecutionAvailability(GetManualExecutionAvailabilityRequest) returns (GetManualExecutionAvailabilityResponse) {
+    option (audit_log_description).description = "get manual execution availability";
+    option (google.api.http) = {
+      get: "/xdr/scheduling/v1/schedule/scan/now/availability"
+    };
+  }
+}
+
+message GetManualExecutionAvailabilityRequest{}
+message GetManualExecutionAvailabilityResponse{
+  google.protobuf.BoolValue can_register = 1;
 }
 
 message ScanNowRequest{}


### PR DESCRIPTION
[sc-14992]

Enhance the scan and schedule functionality by adding a `scanNow` endpoint to register manual executions.
Move the `registerExecution` to the `ingestion-api`. 